### PR TITLE
Remove addon-judges multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ This addon has three main aims:
   should they choose to
 - To make the nether a place suitable (and safe!) place to call home
 
-***Notes for the Addon Jam specifically***
-
-- Seed growth rate is multiplied 5x to speed up the process for judges
-- Nether Crux spread rate is multiplied 5x also
-
 A more detailed description of mechanics and details on plants can be found in my documentation
 wiki [here](https://docs.sefiraat.dev/netheopoiesis/purification)
 

--- a/src/main/java/dev/sefiraat/netheopoiesis/Netheopoiesis.java
+++ b/src/main/java/dev/sefiraat/netheopoiesis/Netheopoiesis.java
@@ -17,9 +17,10 @@ import javax.annotation.Nullable;
 import java.text.MessageFormat;
 
 public class Netheopoiesis extends JavaPlugin implements SlimefunAddon {
-    public static final int CRUX_SPREAD_MULTIPLIER = 5;
-    public static final int CRYSTALLINE_SPREAD_MULTIPLIER = 3;
-    public static final int GROWTH_RATE_MULTIPLIER = 5;
+    // Todo replace with config
+    public static final int CRUX_SPREAD_MULTIPLIER = 1;
+    public static final int CRYSTALLINE_SPREAD_MULTIPLIER = 1;
+    public static final int GROWTH_RATE_MULTIPLIER = 1;
 
     private static Netheopoiesis instance;
 


### PR DESCRIPTION
These multipliers were only for the judges to speed up the process as, I hear, they do not have an infinite amount of time to wait for things to grow :)