### PR TITLE
1.18 Startup fix

### DIFF
--- a/src/main/java/dev/sefiraat/netheopoiesis/api/plant/netheos/TradePool.java
+++ b/src/main/java/dev/sefiraat/netheopoiesis/api/plant/netheos/TradePool.java
@@ -250,7 +250,6 @@ public class TradePool {
         .addTrade(new ItemStack(Material.MUSIC_DISC_WARD), 0)
         .addTrade(new ItemStack(Material.MUSIC_DISC_11), 0)
         .addTrade(new ItemStack(Material.MUSIC_DISC_WAIT), 0)
-        .addTrade(new ItemStack(Material.MUSIC_DISC_5), 0)
         .addTrade(new ItemStack(Material.MUSIC_DISC_PIGSTEP), 40)
         .addTrade(new ItemStack(Material.MUSIC_DISC_OTHERSIDE), 60);
 


### PR DESCRIPTION
One of the music discs added into the trades was 1.19+ only. We need to add it back in, but that can be done later as the current setup isn't suitable for versioned trades being added. 
For now we will remove it and bring it back later