### PR TITLE
Update dough to 1.3.0 to fix Cultivation on 1.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.baked-libs</groupId>
+            <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>1.2.0</version>
+            <version>a2364de77c</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
As with https://github.com/Sefiraat/Cultivation/pull/75

Netheo doesn't work on 1.20.2 because of the heads issue, this PR switches the dough dependency to use Jitpack so we can use dough 1.3.0 (which fixes the heads issue). Loads fine on my test server with SF on latest.