### PR TITLE
Fix bedrock & other solid block breaking

### DIFF
--- a/src/main/java/dev/sefiraat/netheopoiesis/listeners/WaterPlaceListener.java
+++ b/src/main/java/dev/sefiraat/netheopoiesis/listeners/WaterPlaceListener.java
@@ -50,13 +50,15 @@ public class WaterPlaceListener implements Listener {
             ) {
                 block.setWaterlogged(true);
             } else {
-                clickedBlock.getRelative(event.getBlockFace()).setType(Material.WATER);
-            }
+                if (clickedBlock.getRelative(event.getBlockFace()).getType() == Material.AIR) {
+                    clickedBlock.getRelative(event.getBlockFace()).setType(Material.WATER);
+                }
 
-            clickedBlock.setBlockData(blockData, true);
+                clickedBlock.setBlockData(blockData, true);
 
-            if (player.getGameMode() != GameMode.CREATIVE) {
-                event.getItem().setType(Material.BUCKET);
+                if (player.getGameMode() != GameMode.CREATIVE) {
+                    event.getItem().setType(Material.BUCKET);
+                }
             }
         }
     }


### PR DESCRIPTION
If a player places water against a half block (like an iron bar) while sneaking, the opposite face of the `clickedBlock` turns to water, no matter what.

This checks to make sure that opposite face is AIR before setting to water.

Edit: Same as: https://github.com/Sefiraat/Netheopoiesis/issues/68